### PR TITLE
feat: Add support for Augment Items

### DIFF
--- a/src/main/java/dev/latvian/mods/kubejs/thermal/KubeJSThermalPlugin.java
+++ b/src/main/java/dev/latvian/mods/kubejs/thermal/KubeJSThermalPlugin.java
@@ -5,8 +5,14 @@ import cofh.lib.util.constants.ModIds;
 import cofh.thermal.core.init.registries.TCoreRecipeTypes;
 import dev.latvian.mods.kubejs.KubeJSPlugin;
 import dev.latvian.mods.kubejs.recipe.schema.RegisterRecipeSchemasEvent;
+import dev.latvian.mods.kubejs.registry.RegistryInfo;
 
 public class KubeJSThermalPlugin extends KubeJSPlugin {
+	@Override
+	public void init() {
+		RegistryInfo.ITEM.addType("thermal_augment", ThermalAugmentItemBuilder.class, ThermalAugmentItemBuilder::new);
+	}
+
 	@Override
 	public void registerRecipeSchemas(RegisterRecipeSchemasEvent event) {
 		event.namespace(ModIds.ID_THERMAL)

--- a/src/main/java/dev/latvian/mods/kubejs/thermal/ThermalAugmentItemBuilder.java
+++ b/src/main/java/dev/latvian/mods/kubejs/thermal/ThermalAugmentItemBuilder.java
@@ -1,0 +1,54 @@
+package dev.latvian.mods.kubejs.thermal;
+
+import cofh.core.util.helpers.AugmentDataHelper;
+import cofh.thermal.lib.common.item.AugmentItem;
+import dev.latvian.mods.kubejs.item.ItemBuilder;
+import dev.latvian.mods.kubejs.typings.Info;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.item.Item;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static cofh.lib.util.constants.NBTTags.TAG_AUGMENT_BASE_MOD;
+import static cofh.lib.util.constants.NBTTags.TAG_AUGMENT_TYPE_UPGRADE;
+
+public class ThermalAugmentItemBuilder extends ItemBuilder {
+	public transient String augmentType;
+	public transient LinkedHashMap<String, Float> thermalMods;
+
+	public ThermalAugmentItemBuilder(ResourceLocation i) {
+		super(i);
+		augmentType = TAG_AUGMENT_TYPE_UPGRADE;
+		thermalMods = new LinkedHashMap<>();
+	}
+
+	@Info("Sets Thermal augment type, default is Thermal upgrade augment type.")
+	public ThermalAugmentItemBuilder augmentType(String type) {
+		augmentType = type;
+		return this;
+	}
+
+	@Info("Sets a Thermal augment numeric modifier by key. Can be called multiple times for different keys.")
+	public ThermalAugmentItemBuilder thermalMod(String key, float value) {
+		thermalMods.put(key, value);
+		return this;
+	}
+
+	@Info("Convenience alias for setting Thermal BaseMod.")
+	public ThermalAugmentItemBuilder baseMod(float value) {
+		thermalMods.put(TAG_AUGMENT_BASE_MOD, value);
+		return this;
+	}
+
+	@Override
+	public Item createObject() {
+		var builder = AugmentDataHelper.builder().type(augmentType);
+		for (Map.Entry<String, Float> entry : thermalMods.entrySet()) {
+			builder.mod(entry.getKey(), entry.getValue());
+		}
+
+		return new AugmentItem(createItemProperties(),
+				builder.build());
+	}
+}


### PR DESCRIPTION
This PR adds a natural way to create custom Thermal augments directly in KubeJS (fixes #21).

Previously, custom augment behavior had to be written into output NBT (for example, `AugmentData` in recipe outputs). That caused upgrade-chain issues, especially with AE2 patterns, because augment data was not truly part of the item itself.

With this PR, augment properties are defined on the item at registration time.  
Recipes can then input or output the item normally, without embedding augment NBT each time.

The functions have been tested in 1.20.1 Modpack *Star Technology* (to be more precisely, I mean I tested it locally).

## Why this is better

- Augment data is attached to the item definition, not recipe output NBT.
- Recipes are simpler and easier to maintain.
- Custom augments become reusable across multiple recipes.

## Minimal examples

### 1) Create a Dynamo augment (0.9x fuel, 1.5x speed)

```js
StartupEvents.registry('item', event => {
  event.create('my_custom_dynamo_kit', 'thermal_augment')
    .augmentType('Dynamo')
    .thermalMod('DynamoEnergy', 0.9)
    .thermalMod('DynamoPower', 1.5);
});
```

### 2) Create a global 8x upgrade augment

```js
StartupEvents.registry('item', event => {
  event.create('global_8x_upgrade_kit', 'thermal_augment')
    .augmentType('Upgrade')
    .thermalMod('BaseMod', 8.0);
});
```